### PR TITLE
Genericly test overlay support on the storage directory

### DIFF
--- a/wrapdocker
+++ b/wrapdocker
@@ -100,7 +100,6 @@ fi
 # find filesystem below /var/lib/docker
 STORAGE_DIR="/var/lib/docker"
 mkdir -p "${STORAGE_DIR}"
-STORAGE_DIR_FS=$(df -PTh "${STORAGE_DIR}" | awk '{print $2}' | tail -1)
 
 # Smoke test the overlay filesystem:
 # 1. create smoke dir in the storage dir being mounted (possibly on an overlay fs)

--- a/wrapdocker
+++ b/wrapdocker
@@ -102,16 +102,16 @@ STORAGE_DIR="/var/lib/docker"
 mkdir -p "${STORAGE_DIR}"
 STORAGE_DIR_FS=$(df -PTh "${STORAGE_DIR}" | awk '{print $2}' | tail -1)
 
-# Smoke test overlay over overlay:
-# 1. create smoke dir in the storage dir being mounted on an overlay fs
+# Smoke test the overlay filesystem:
+# 1. create smoke dir in the storage dir being mounted (possibly on an overlay fs)
 # 2. try to mount an overlay fs on top of the smoke dir
-# 3. try to write a file in the overlay-over-overlay mount
-# 4. if that fails set OOO_BROKEN=true
+# 3. try to write a file in the overlay mount
+# 4. if that succeeds set OVERLAY_WORKS=true
 #
 # Rational: There are kernels with broken overlay-over-overlay support (4.2 and
 # probably 3.19). On those it's possible to mount an overlay in an overlay, but
 # writing to a file results in a "No device" error.
-if [ "${STORAGE_DIR_FS}" = "overlay" ] && [ "${STORAGE_FS}" = "overlay" ]; then
+if [ "${STORAGE_FS}" = "overlay" ]; then
   D="${STORAGE_DIR}/smoke"
   mkdir -p "${D}/upper" "${D}/lower" "${D}/work" "${D}/mount"
 
@@ -122,9 +122,10 @@ if [ "${STORAGE_DIR_FS}" = "overlay" ] && [ "${STORAGE_FS}" = "overlay" ]; then
   rm -rf "${D}" || true
 fi
 
-# Unless using overlay over overlay or overlay over overlay is broken, create an ext3 loop device as an intermediary layer.
-# The max size of the loop device is $VAR_LIB_DOCKER_SIZE in GB (default=5).
-if [ "${STORAGE_DIR_FS}" != "overlay" ] || [ "${STORAGE_FS}" != "overlay" ] || [ "${OOO_BROKEN}" == true ]; then
+# If another filesystem than overlay is used or overlay does not work, create
+# an ext3 loop device as an intermediary layer. The max size of the loop device
+# is $VAR_LIB_DOCKER_SIZE in GB (default=5).
+if [ "${STORAGE_FS}" != "overlay" -o ${OVERLAY_WORKS} != true ]; then
   STORAGE_FILE="/data/docker"
   VAR_LIB_DOCKER_SIZE=${VAR_LIB_DOCKER_SIZE:-5}
   mkdir -p "$(dirname "${STORAGE_FILE}")"


### PR DESCRIPTION
The old code only tested overlay-over-overlay. In any other case, it switched
to a loop mounted ext4 with overlay or aufs on-top.

This PR activates the smoke test independently from the storage filesystem.
Hence, we will use overlay natively on the /var/lib/docker also if e.g. it is
mounted from the host as a volume (for image caching purposes).
