### PR TITLE
Add option to disable network bridging to the parent docker network

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 581
         && \
     apt-get clean
 
-ENV WRAPPER_VERSION 0.2.3
+ENV WRAPPER_VERSION 0.2.4
 COPY ./wrapdocker /usr/local/bin/
 
 ENTRYPOINT ["wrapdocker"]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-### Mesos Slave Docker-in-Docker (dind)
+# Mesos Slave Docker-in-Docker (dind)
 
 Mesos-Slave that runs in a Ubuntu-based Docker container.
 
 Launches tasks using the included Docker Engine, rather than the host's Docker Engine.
 
-#### Features
+## Features
 
 - Runs Mesos tasks inside the container (instead of in the parent Docker env).
 - Mesos tasks (in docker containers) are stopped when the mesos-slave-dind container is stopped.
@@ -12,15 +12,23 @@ Launches tasks using the included Docker Engine, rather than the host's Docker E
   - Allocates disk space (via loop mount) to allow mounting AUFS on AUFS
 - Allocates IP space on the parent Docker's network, making docker-in-docker containers IP accessible from the host.
 
-#### Required Docker Parameters
+## Networking
+
+There are two networking mode options: default & bridged.
+
+By default, the inner docker daemon gets its own network. These inner container IPs will not be accessible by the host.
+
+Bridged networking mode can be enabled by populating `DOCKER_NETWORK_OFFSET` (env var). In bridged networking mode, containers launched by the inner docker daemon will be given IPs on the host docker network. This requires reserving a range of IPs on the host docker network for each mesos-slave-dind container by specifying an offset (`DOCKER_NETWORK_OFFSET`) and a size (`DOCKER_NETWORK_SIZE`). The offset should be specific to the container, and the range (offset <-> offset + size - 1) should not overlap with other reserved ranges.
+
+## Required Docker Parameters
 
 - `--privileged=true` - Provides access to cgroups
 
-#### Recommended Environment Variables
+## Recommended Environment Variables
 
 - **MESOS_CONTAINERIZERS** - Include docker to enable running tasks as docker containers. Ex: `docker,mesos`
 - **MESOS_RESOURCES** - Specify resources to avoid oversubscribing via auto-detecting host resources. Ex: `cpus:4;mem:1280;disk:25600;ports:[21000-21099]`
-- **DOCKER_NETWORK_OFFSET** - Specify an IP offset to give each mesos-slave-dind container (default: `0.0.1.0`). Ex: `0.0.1.0` (slave A), `0.0.2.0` (slave B)
+- **DOCKER_NETWORK_OFFSET** - Specify an IP offset to give each mesos-slave-dind container (enables bridged network mode). Ex: `0.0.1.0` (slave A), `0.0.2.0` (slave B)
 - **DOCKER_NETWORK_SIZE** - Specify a CIDR range to apply to the above offset (default=`24`).
 - **VAR_LIB_DOCKER_SIZE** - Specify the max size (in GB) of the loop device to be mounted at /var/lib/docker (default=`5`). This is only used if OverlayFS is not supported by the kernel or the parent docker is configured to use AUFS.
 
@@ -28,7 +36,7 @@ Source: <https://github.com/mesosphere/docker-containers/tree/master/mesos-slave
 
 Inspiration: <https://github.com/jpetazzo/dind>
 
-### License
+## License
 
 Copyright 2015 [The Mesos Slave Docker-in-Docker Authors](./AUTHORS.md)
 

--- a/wrapdocker
+++ b/wrapdocker
@@ -136,52 +136,59 @@ if [ "${STORAGE_FS}" != "overlay" -o "${OVERLAY_WORKS}" == false ]; then
   mount -o loop "${STORAGE_FILE}" "${STORAGE_DIR}"
 fi
 
+DOCKER_DAEMON_ARGS="${DOCKER_DAEMON_ARGS:-} --storage-driver=${STORAGE_FS}"
+
 # If a pidfile is still around (for example after a container restart),
 # delete it so that docker can start.
 rm -rf /var/run/docker.pid
 
-# create docker0 bridge manually and attach it to the veth interface eth0
-brctl addbr docker0
-brctl addif docker0 eth0
-ip link set docker0 up
+# Bridge the containerized docker network to the host docker network.
+# To enable this bridge, specify an IP offset for this container to use.
+# Other containers on the same host should have different offsets
+# such that the IPs within the range (offset <-> offset + size - 1) do not overlap.
+if [ ! -z "${DOCKER_NETWORK_OFFSET:-}" ]; then
+  # create docker0 bridge manually and attach it to the veth interface eth0
+  brctl addbr docker0
+  brctl addif docker0 eth0
+  ip link set docker0 up
 
-# move ip to the bridge and restore routing via the old gateway
-IP_CIDR=$(ip addr show eth0 | grep -w inet | awk '{ print $2; }')
-IP=$(echo $IP_CIDR | sed 's,/.*,,')
-NETWORK_SIZE=$(echo $IP_CIDR | sed 's,.*/,,')
-DEFAULT_ROUTE=$(ip route | grep default | sed 's/eth0/docker0/')
+  # move ip to the bridge and restore routing via the old gateway
+  IP_CIDR=$(ip addr show eth0 | grep -w inet | awk '{ print $2; }')
+  IP=$(echo $IP_CIDR | sed 's,/.*,,')
+  NETWORK_SIZE=$(echo $IP_CIDR | sed 's,.*/,,')
+  DEFAULT_ROUTE=$(ip route | grep default | sed 's/eth0/docker0/')
 
-ip addr del $IP_CIDR dev eth0
-ip addr add $IP_CIDR dev docker0
-ip route add $DEFAULT_ROUTE
+  ip addr del $IP_CIDR dev eth0
+  ip addr add $IP_CIDR dev docker0
+  ip route add $DEFAULT_ROUTE
 
-# compute a network for the containers to live in
-# by adding DOCKER_NETWORK_OFFSET to the current IP and cutting off
-# non-network bits according to DOCKER_NETWORK_SIZE
-DOCKER_NETWORK_SIZE=${DOCKER_NETWORK_SIZE:-24}
-DOCKER_NETWORK_OFFSET=${DOCKER_NETWORK_OFFSET:-0.0.1.0}
-NETWORK=$(ip route | grep docker0 | grep -v default | sed 's,/.*,,')
+  # compute a network for the containers to live in
+  # by adding DOCKER_NETWORK_OFFSET to the current IP and cutting off
+  # non-network bits according to DOCKER_NETWORK_SIZE
+  DOCKER_NETWORK_SIZE=${DOCKER_NETWORK_SIZE:-24}
+  NETWORK=$(ip route | grep docker0 | grep -v default | sed 's,/.*,,')
 
-IFS=. read -r i1 i2 i3 i4 <<< $IP
-IFS=. read -r n1 n2 n3 n4 <<< $NETWORK
-IFS=. read -r o1 o2 o3 o4 <<< $DOCKER_NETWORK_OFFSET
-IFS=. read -r w1 w2 w3 w4 <<< $(ipcalc $IP_CIDR | grep Wildcard | awk '{print $2;}')
+  IFS=. read -r i1 i2 i3 i4 <<< $IP
+  IFS=. read -r n1 n2 n3 n4 <<< $NETWORK
+  IFS=. read -r o1 o2 o3 o4 <<< $DOCKER_NETWORK_OFFSET
+  IFS=. read -r w1 w2 w3 w4 <<< $(ipcalc $IP_CIDR | grep Wildcard | awk '{print $2;}')
 
-IP_PLUS_OFFSET=$(printf "%d.%d.%d.%d\n" \
-  "$(( n1 + ((i1 - n1 + o1) & w1) ))" \
-  "$(( n2 + ((i2 - n2 + o2) & w2) ))" \
-  "$(( n3 + ((i3 - n3 + o3) & w3) ))" \
-  "$(( n4 + ((i4 - n4 + o4) & w4) ))")
+  IP_PLUS_OFFSET=$(printf "%d.%d.%d.%d\n" \
+    "$(( n1 + ((i1 - n1 + o1) & w1) ))" \
+    "$(( n2 + ((i2 - n2 + o2) & w2) ))" \
+    "$(( n3 + ((i3 - n3 + o3) & w3) ))" \
+    "$(( n4 + ((i4 - n4 + o4) & w4) ))")
 
-FIXED_CIDR=$(ipcalc $IP_PLUS_OFFSET/$DOCKER_NETWORK_SIZE | grep Network | awk '{print $2;}')
-echo "Using network $FIXED_CIDR for docker containers"
+  FIXED_CIDR=$(ipcalc $IP_PLUS_OFFSET/$DOCKER_NETWORK_SIZE | grep Network | awk '{print $2;}')
+  echo "Using network $FIXED_CIDR for docker containers"
+
+  # let docker reuse the given IP. If you run more than one dind slave, add
+  # --fixed-cidr=a.b.c.d/24 to DOCKER_DAEMON_ARGS with disjunct networks.
+  DOCKER_DAEMON_ARGS="${DOCKER_DAEMON_ARGS} --bip=${IP_CIDR} --fixed-cidr=${FIXED_CIDR}"
+fi
 
 # stop docker daemon on shutdown to avoid loopback leaks
 trap "service docker stop" EXIT
-
-# let docker reuse the given IP. If you run more than one dind slave, add
-# --fixed-cidr=a.b.c.d/24 to DOCKER_DAEMON_ARGS with disjunct networks.
-DOCKER_DAEMON_ARGS="${DOCKER_DAEMON_ARGS} --bip=${IP_CIDR} --fixed-cidr=${FIXED_CIDR} --storage-driver=${STORAGE_FS}"
 
 # start docker daemon
 if docker daemon --help &>/dev/null; then


### PR DESCRIPTION
- Bridge disabled by default, enabled by DOCKER_NETWORK_BRIDGE=true
