### PR TITLE
Downgrade to Docker 1.10.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,21 +9,23 @@ RUN apt-get update -qq && \
         lxc \
         iptables \
         ipcalc \
+        linux-image-extra-virtual \
         && \
     apt-get clean
 
 # Install specific Docker version
-ENV DOCKER_VERSION 1.12.1-0~trusty
+ENV DOCKER_VERSION 1.10.3-0~trusty
 RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
     mkdir -p /etc/apt/sources.list.d && \
     echo deb https://apt.dockerproject.org/repo ubuntu-trusty main > /etc/apt/sources.list.d/docker.list && \
     apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get -qqy --purge remove docker-engine && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -qqy \
         docker-engine=${DOCKER_VERSION} \
         && \
     apt-get clean
 
-ENV WRAPPER_VERSION 0.2.4
+ENV WRAPPER_VERSION 0.3.0
 COPY ./wrapdocker /usr/local/bin/
 
 ENTRYPOINT ["wrapdocker"]

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,8 @@
 ## Release Process
 
 1. Modify master branch
-2. Make docker image
+
+1. Make docker image
 
   ```
   $ make image
@@ -10,14 +11,14 @@
   Successfully built 1e0c8618d736
   ```
 
-3. Tag docker image
+1. Tag docker image
 
   ```
   $ make tag
   docker tag mesosphere/mesos-slave-dind:latest mesosphere/mesos-slave-dind:0.2.3_mesos-0.24.0_docker-1.7.1_ubuntu-14.04.3
   ```
 
-4. Create release branch
+1. Create release branch
 
   ```
   $ git checkout -b release-${VERSION}
@@ -25,20 +26,22 @@
 
   (VERSION is the docker tag produced by the previous step)
 
-5. Push release branch
+1. Push release branch
 
   ```
   $ git push --set-upstream origin release-${VERSION}
   ```
 
-6. Tag git release
+1. Create & merge release branch to master branch
+
+1. Tag git release
 
   ```
   $ make release
   git tag -a "${VERSION}" -m "mesos-slave-dind version ${VERSION}"
   ```
 
-7. Push git tag
+1. Push git tag
 
   ```
   $ git push --follow-tags
@@ -49,7 +52,7 @@
    * [new tag]         0.2.3_mesos-0.24.0_docker-1.7.1_ubuntu-14.04.3 -> 0.2.3_mesos-0.24.0_docker-1.7.1_ubuntu-14.04.3
   ```
 
-8. Push docker image
+1. Push docker image
 
   ```
   $ make push


### PR DESCRIPTION
- Docker 1.11 and 1.12 disallow overlay-on-overlay
